### PR TITLE
Release v0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
+          - "3.2"
     steps:
       - uses: zendesk/checkout@v2
       - name: Set up Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,11 @@
 PATH
   remote: .
   specs:
-    luhn_checksum (0.1.2)
+    luhn_checksum (0.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    appraisal (1.0.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     ast (2.4.2)
     bump (0.10.0)
     minitest (5.2.0)
@@ -17,7 +13,7 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     rainbow (3.1.1)
-    rake (10.3.1)
+    rake (13.0.6)
     regexp_parser (2.5.0)
     rexml (3.2.5)
     rubocop (1.30.0)
@@ -32,14 +28,12 @@ GEM
     rubocop-ast (1.18.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
-    thor (0.19.1)
     unicode-display_width (2.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal
   bump
   bundler
   luhn_checksum!

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@
 
 require 'bundler/gem_tasks'
 require 'bump/tasks'
-require 'appraisal'
 require 'rake/testtask'
 require 'rubocop/rake_task'
 

--- a/luhn_checksum.gemspec
+++ b/luhn_checksum.gemspec
@@ -12,9 +12,8 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = 'luhn_checksum'
-  gem.version       = '0.1.2'
+  gem.version       = '0.2.0'
 
-  gem.add_development_dependency('appraisal')
   gem.add_development_dependency('bump')
   gem.add_development_dependency('bundler')
   gem.add_development_dependency('rake')


### PR DESCRIPTION
Tests with Ruby 3.1 & 3.2.

Also bumps Rack for Ruby 3.2 compatibility, removes `Appraisal`.