### PR TITLE
Add tests with Ruby 3.4, drop support for Ruby below 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.6"
-          - "2.7"
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
-        uses: zendesk/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
@@ -28,10 +25,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: zendesk/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.1"
           bundler-cache: true
       - run: bundle exec rake rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.1
 
 Metrics:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,27 +8,33 @@ GEM
   specs:
     ast (2.4.2)
     bump (0.10.0)
-    minitest (5.2.0)
-    parallel (1.22.1)
-    parser (3.1.2.0)
+    json (2.9.1)
+    language_server-protocol (3.17.0.3)
+    minitest (5.25.4)
+    parallel (1.26.3)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.5.0)
-    rexml (3.2.5)
-    rubocop (1.30.0)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
+    rubocop (1.70.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.18.0, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.36.2, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.18.0)
-      parser (>= 3.1.1.0)
-    ruby-progressbar (1.11.0)
-    unicode-display_width (2.1.0)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.37.0)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   ruby
@@ -42,4 +48,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.3.12
+   2.6.2

--- a/luhn_checksum.gemspec
+++ b/luhn_checksum.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.description   = 'Efficient Luhn checksum validator'
   gem.summary       = 'Efficient Luhn checksum validator'
   gem.homepage      = 'https://github.com/zendesk/luhn_checksum'
-  gem.required_ruby_version = '>= 2.6.0'
+  gem.required_ruby_version = '>= 3.1'
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/test/luhn_checksum_test.rb
+++ b/test/luhn_checksum_test.rb
@@ -5,7 +5,7 @@ require_relative 'helper'
 # Test data courtsey of:
 # * https://github.com/square/luhnybin
 # * http://en.wikipedia.org/wiki/Luhn_algorithm
-class LuhnChecksumTest < MiniTest::Test
+class LuhnChecksumTest < Minitest::Test
   describe 'Luhn filter' do
     it 'matches checksums' do
       real_luhns = ['123451234512348', '5678', '49927398716', '1234567812345670', '56613959932537']


### PR DESCRIPTION
Adds tests with Ruby 3.4, drops support for EOL Ruby versions, updates all test dependencies.