### PR TITLE
Switch to trusted publishing workflow and run it on version.rb changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish to RubyGems.org
+
+on:
+  push:
+    branches: main
+    paths: lib/luhn_checksum/version.rb
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    if: github.repository_owner == 'zendesk'
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ digits. An exception will be thrown if non-digits are passed in.
 The number `6789` will be considered valid, even though most credit card numbers are between
 13 and 19 digits in length.
 
+### Releasing a new version
+A new version is published to RubyGems.org every time a change to `version.rb` is pushed to the `main` branch.
+In short, follow these steps:
+1. Update `version.rb`,
+2. run `bundle lock` to update `Gemfile.lock`,
+3. merge this change into `main`, and
+4. look at [the action](https://github.com/zendesk/luhn_checksum/actions/workflows/publish.yml) for output.
+
+To create a pre-release from a non-main branch:
+1. change the version in `version.rb` to something like `1.2.0.pre.1` or `2.0.0.beta.2`,
+2. push this change to your branch,
+3. go to [Actions → “Publish to RubyGems.org” on GitHub](https://github.com/zendesk/luhn_checksum/actions/workflows/publish.yml),
+4. click the “Run workflow” button,
+5. pick your branch from a dropdown.
+
 ### License
 
 Apache License 2.0

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler/gem_tasks'
+require 'bundler/setup'
 require 'bump/tasks'
 require 'rake/testtask'
 require 'rubocop/rake_task'

--- a/lib/luhn_checksum/version.rb
+++ b/lib/luhn_checksum/version.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+module LuhnChecksum
+  VERSION = '0.2.0'
+end

--- a/luhn_checksum.gemspec
+++ b/luhn_checksum.gemspec
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'lib/luhn_checksum/version'
+
 Gem::Specification.new do |gem|
   gem.authors       = ['Eric Chapweske', 'Gary Grossman']
   gem.email         = ['ggrossman@zendesk.com']
@@ -12,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = 'luhn_checksum'
-  gem.version       = '0.2.0'
+  gem.version       = LuhnChecksum::VERSION
 
   gem.add_development_dependency('bump')
   gem.add_development_dependency('bundler')


### PR DESCRIPTION
Switches to [a Trusted Publishing workflow](https://guides.rubygems.org/trusted-publishing/).
This workflow will run whenever `version.rb` is changed in the `main` branch.
Since the workflow loads `bundler/gem_tasks` explicitly, we don’t need to do that in the Rakefile (but we want to ensure that `bundler/setup` is present there).
Setting `ENV["gem_push"]` is also not necessary anymore.

`bundler-cache` for `setup-ruby` is set to false to prevent [cache poisoning attacks](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/).
Finally, we add a description of the new release process. Our README and CONTRIBUTING files don’t have a standard structure, so please check that we have updated a correct file and that the new section makes sense for this gem.
- [ ] Release description has been updated correctly.